### PR TITLE
Added RustCamp 2015 talks to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ See also [http://arewewebyet.com/](http://arewewebyet.com/)
 * [Rust CI](http://www.rust-ci.org/) — a [Travis CI](https://travis-ci.com) dashboard for Rust projects
 * [Rust Guidelines](http://aturon.github.io/)
 * [rust-learning](https://github.com/ctjhoa/rust-learning) — a collection of useful resources to learn Rust
-
+* [RustCamp 2015 Talks](http://confreaks.tv/events/rustcamp2015)
 
 ## Development tools
 


### PR DESCRIPTION
I thought of making a videos or conference section, but I think once there are more conferences or known video series then a section for those will make sense.