### PR TITLE
Added arrayfire-rust, inquerest and queryst

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ See also [http://areweideyet.com/](http://areweideyet.com/).
   * [stainless-steel/lapack](https://github.com/stainless-steel/lapack) — [LAPACK](http://en.wikipedia.org/wiki/LAPACK) bindings [<img src="https://travis-ci.org/stainless-steel/lapack.svg?branch=master">](https://travis-ci.org/stainless-steel/lapack)
 * OpenCL
   * [luqmana/rust-opencl](https://github.com/luqmana/rust-opencl) — [OpenCL](https://www.khronos.org/opencl/) bindings [<img src="https://travis-ci.org/luqmana/rust-opencl.svg?branch=master">](https://travis-ci.org/luqmana/rust-opencl)
+  * [arrayfire/arrayfire-rust](https://github.com/arrayfire/arrayfire-rust) - Arrayfire Rust Bindings
 * Scirust
   * [indigits/scirust](https://github.com/indigits/scirust) — scientific computing library in Rust [![Build Status](https://travis-ci.org/indigits/scirust.svg?branch=master)](https://travis-ci.org/indigits/scirust)   
 
@@ -358,6 +359,8 @@ See also [http://areweideyet.com/](http://areweideyet.com/).
   * [Geal/nom](https://github.com/Geal/nom) — parser combinator library [<img src="https://travis-ci.org/Geal/nom.svg?branch=master">](https://travis-ci.org/Geal/nom)
   * [kevinmehall/rust-peg](https://github.com/kevinmehall/rust-peg) — Parsing Expression Grammar (PEG) parser generator
   * [Marwes/combine](https://github.com/Marwes/combine) — parser combinator library [<img src="https://travis-ci.org/Marwes/combine.svg?branch=master">](https://travis-ci.org/Marwes/combine)
+  * [ivanceras/inquerest](https://github.com/ivanceras/inquerest) - url parameter parser for rest filter inquiry [![Build Status](https://travis-ci.org/ivanceras/inquerest.svg?branch=master)](https://travis-ci.org/ivanceras/inquerest)
+ * [rustless/queryst](https://github.com/rustless/queryst) - A query string parsing library for Rust inspired by https://github.com/hapijs/qs [![Build Status](https://travis-ci.org/rustless/queryst.svg?branch=master)](https://travis-ci.org/rustless/queryst)
 
 
 ### Platform specific


### PR DESCRIPTION
arrayfire-rust - rust binding for arrayfire which uses opencl underneath the hood
inquerest and queryst - url param parsers 