### PR TITLE
Add "mdBook" in "Applications written in Rust"

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The goal is to have only projects that are mostly stable and useful to users.
 
 ## Applications written in Rust
 
+* [azerupi/mdBook](https://github.com/azerupi/mdBook) — a command line utility to create books from markdown files [<img src="https://travis-ci.org/azerupi/mdBook.svg?branch=master">](https://travis-ci.org/azerupi/mdBook)
 * [bluejekyll/trust-dns](https://github.com/bluejekyll/trust-dns) — a DNS-server [<img src="https://travis-ci.org/bluejekyll/trust-dns.svg?branch=master">](https://travis-ci.org/bluejekyll/trust-dns)
 * [BurntSushi/xsv](https://github.com/BurntSushi/xsv) — a fast CSV command line tool (slicing, indexing, selecting, searching, sampling, etc.) [<img src="https://travis-ci.org/BurntSushi/xsv.svg?branch=master">](https://travis-ci.org/BurntSushi/xsv)
 * [buster/rrun](https://github.com/buster/rrun) — a command launcher for Linux, similar to gmrun  [<img src="https://travis-ci.org/buster/rrun.svg?branch=master">](https://travis-ci.org/buster/rrun)


### PR DESCRIPTION
Hi,
I took the liberty of adding my project ([mdBook](https://github.com/azerupi/mdBook)) to the list of applications written in Rust.

If it doesn't belong in this list just close this PR, I would totally understand :)