### PR TITLE
Update Rust extensions for VSCode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,8 +265,8 @@ See also [http://areweideyet.com/](http://areweideyet.com/) and [Rust and IDEs](
   * Visual Studio
     * [PistonDevelopers/VisualRust](https://github.com/PistonDevelopers/VisualRust) — a Visual Studio extension for Rust [<img src="https://travis-ci.org/PistonDevelopers/VisualRust.svg?branch=master">](https://travis-ci.org/PistonDevelopers/VisualRust)
   * [Visual Studio Code](https://code.visualstudio.com/)
-    * [saviorisdead/RustyCode](https://github.com/saviorisdead/RustyCode)
-    * [KalitaAlexey/vscode-rust](https://github.com/KalitaAlexey/vscode-rust) — a fork of RustyCode
+    * [saviorisdead/RustyCode](https://marketplace.visualstudio.com/items?itemName=saviorisdead.RustyCode) (unmaintained)
+    * [KalitaAlexey/vscode-rust](https://marketplace.visualstudio.com/items?itemName=kalitaalexey.vscode-rust) — a fork of RustyCode
 
 ### Pattern Recognition
 


### PR DESCRIPTION
Add a note that RustyCode in unmaintained.
Change links to point to VSCode marketplace.